### PR TITLE
all tasks done

### DIFF
--- a/lesson5/hw/float_map/mutex_set.go
+++ b/lesson5/hw/float_map/mutex_set.go
@@ -1,0 +1,31 @@
+// Package floatmap contains a few
+// Set datastucture implementations
+// using different sync primitives
+package floatmap
+
+import "sync"
+
+type MutexSet struct {
+	mx   sync.Mutex
+	data map[float32]struct{}
+}
+
+func NewMutexSet(size int) *MutexSet {
+	data := make(map[float32]struct{}, size)
+	return &MutexSet{data: data}
+}
+
+func (ms *MutexSet) Add(elem float32) {
+	ms.mx.Lock()
+	defer ms.mx.Unlock()
+
+	ms.data[elem] = struct{}{}
+}
+
+func (ms *MutexSet) Has(elem float32) bool {
+	ms.mx.Lock()
+	defer ms.mx.Unlock()
+
+	_, ok := ms.data[elem]
+	return ok
+}

--- a/lesson5/hw/float_map/rwmutex_set.go
+++ b/lesson5/hw/float_map/rwmutex_set.go
@@ -1,0 +1,31 @@
+// Package floatmap contains a few
+// Set datastucture implementations
+// using different sync primitives
+package floatmap
+
+import "sync"
+
+type RWMutexSet struct {
+	mx   sync.RWMutex
+	data map[float32]struct{}
+}
+
+func NewRWMutexSet(size int) *RWMutexSet {
+	data := make(map[float32]struct{}, size)
+	return &RWMutexSet{data: data}
+}
+
+func (ms *RWMutexSet) Add(elem float32) {
+	ms.mx.Lock()
+	defer ms.mx.Unlock()
+
+	ms.data[elem] = struct{}{}
+}
+
+func (ms *RWMutexSet) Has(elem float32) bool {
+	ms.mx.RLock()
+	defer ms.mx.RUnlock()
+
+	_, ok := ms.data[elem]
+	return ok
+}

--- a/lesson5/hw/float_map/set_test.go
+++ b/lesson5/hw/float_map/set_test.go
@@ -1,0 +1,115 @@
+package floatmap
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+var (
+	setSize              = 10
+	benchWorkers         = 1000
+	benchWritersPctTable = []int{0, 10, 50, 90, 100}
+)
+
+type SetIface interface {
+	Add(float32)
+	Has(float32) bool
+}
+
+func baseSetTests(t *testing.T, set SetIface) {
+	testValue := float32(5.0)
+
+	// firstly, value not exists
+	expect := false
+	got := set.Has(testValue)
+	if got != expect {
+		t.Errorf("check not existing value failed: got %v, expect %v", got, expect)
+	}
+	// add value
+	set.Add(testValue)
+	// now it should exists
+	expect = true
+	got = set.Has(testValue)
+	if got != expect {
+		t.Errorf("check existing value failed: got %v, expect %v", got, expect)
+	}
+}
+
+func TestMutexSet(t *testing.T) {
+	testSet := NewMutexSet(setSize)
+	baseSetTests(t, testSet)
+}
+
+func TestRwMutexSet(t *testing.T) {
+	testSet := NewRWMutexSet(setSize)
+	baseSetTests(t, testSet)
+}
+
+func TestSyncMapSet(t *testing.T) {
+	testSet := NewSyncMapSet(setSize)
+	baseSetTests(t, testSet)
+}
+
+//
+// Benchmarks
+//
+
+func baseSetBench(b *testing.B, set SetIface, writePct int) {
+	if writePct > 100 || writePct < 0 {
+		b.Fatalf("writers %% should be int in [0, 100], got: %d", writePct)
+	}
+	writers := benchWorkers * writePct / 100
+	readers := benchWorkers - writers
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < b.N; i++ {
+		wg.Add(benchWorkers)
+		// start a few goroutines
+		// readers
+		for g := 0; g < readers; g++ {
+			go func(i int) {
+				defer wg.Done()
+				set.Has(float32(i))
+			}(g)
+		}
+		// writers
+		for g := 0; g < writers; g++ {
+			go func(i int) {
+				defer wg.Done()
+				set.Add(float32(i))
+			}(g)
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkMutexSet(b *testing.B) {
+	for _, writePct := range benchWritersPctTable {
+		benchDescr := fmt.Sprintf("test set write/read with %d%% writers", writePct)
+		b.Run(benchDescr, func(b *testing.B) {
+			testSet := NewMutexSet(setSize)
+			baseSetBench(b, testSet, writePct)
+		})
+	}
+}
+
+func BenchmarkRWMutexSet(b *testing.B) {
+	for _, writePct := range benchWritersPctTable {
+		benchDescr := fmt.Sprintf("test set write/read with %d%% writers", writePct)
+		b.Run(benchDescr, func(b *testing.B) {
+			testSet := NewRWMutexSet(setSize)
+			baseSetBench(b, testSet, writePct)
+		})
+	}
+}
+
+func BenchmarkSyncMapSet(b *testing.B) {
+	for _, writePct := range benchWritersPctTable {
+		benchDescr := fmt.Sprintf("test set write/read with %d%% writers", writePct)
+		b.Run(benchDescr, func(b *testing.B) {
+			testSet := NewSyncMapSet(setSize)
+			baseSetBench(b, testSet, writePct)
+		})
+	}
+}

--- a/lesson5/hw/float_map/syncmap_set.go
+++ b/lesson5/hw/float_map/syncmap_set.go
@@ -1,0 +1,23 @@
+// Package floatmap contains a few
+// Set datastucture implementations
+// using different sync primitives
+package floatmap
+
+import "sync"
+
+type SyncMapSet struct {
+	data sync.Map
+}
+
+func NewSyncMapSet(size int) *SyncMapSet {
+	return &SyncMapSet{}
+}
+
+func (ms *SyncMapSet) Add(elem float32) {
+	ms.data.Store(elem, struct{}{})
+}
+
+func (ms *SyncMapSet) Has(elem float32) bool {
+	_, ok := ms.data.Load(elem)
+	return ok
+}

--- a/lesson5/hw/wait_group/main.go
+++ b/lesson5/hw/wait_group/main.go
@@ -1,0 +1,26 @@
+// Package main simulates WaitGroup usage
+package main
+
+import (
+	"log"
+	"sync"
+)
+
+const workers = 10
+
+func main() {
+	wg := sync.WaitGroup{}
+
+	log.Println("Started")
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(workerId int) {
+			defer wg.Done()
+			log.Printf("Goroutine %d working...", workerId)
+		}(i)
+	}
+	wg.Wait()
+
+	log.Println("Finished")
+}


### PR DESCRIPTION
### задание 1 ###

файл wail_group/main.go

### задание 2 ###

отдельного файла нет, но в папке float_map несколько раз встречается Unlock() в дефере

### задание 3 ###

Три реализации: с обычным, RW мьютексами и sync.Map. Ниже результаты бенчмарка...

```
pkg: geekbrains/examples/lesson5/hw/float_map
cpu: Intel(R) Core(TM) i5-10310U CPU @ 1.70GHz
BenchmarkMutexSet/test_set_write/read_with_0%_writers-4         	    3778	    329111 ns/op	      24 B/op	       0 allocs/op
BenchmarkMutexSet/test_set_write/read_with_10%_writers-4        	    2943	    419508 ns/op	      21 B/op	       0 allocs/op
BenchmarkMutexSet/test_set_write/read_with_50%_writers-4        	    2704	    451384 ns/op	      32 B/op	       0 allocs/op
BenchmarkMutexSet/test_set_write/read_with_90%_writers-4        	    2584	    473899 ns/op	      40 B/op	       0 allocs/op
BenchmarkMutexSet/test_set_write/read_with_100%_writers-4       	    2456	    481566 ns/op	      40 B/op	       0 allocs/op
BenchmarkRWMutexSet/test_set_write/read_with_0%_writers-4       	    3560	    327984 ns/op	       0 B/op	       0 allocs/op
BenchmarkRWMutexSet/test_set_write/read_with_10%_writers-4      	    3331	    371150 ns/op	      13 B/op	       0 allocs/op
BenchmarkRWMutexSet/test_set_write/read_with_50%_writers-4      	    2506	    502061 ns/op	      26 B/op	       0 allocs/op
BenchmarkRWMutexSet/test_set_write/read_with_90%_writers-4      	    2004	    599419 ns/op	      56 B/op	       0 allocs/op
BenchmarkRWMutexSet/test_set_write/read_with_100%_writers-4     	    2245	    573167 ns/op	      44 B/op	       0 allocs/op
BenchmarkSyncMapSet/test_set_write/read_with_0%_writers-4       	    3799	    328968 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMapSet/test_set_write/read_with_10%_writers-4      	    3908	    344120 ns/op	    1998 B/op	     199 allocs/op
BenchmarkSyncMapSet/test_set_write/read_with_50%_writers-4      	    3344	    342585 ns/op	   10021 B/op	     999 allocs/op
BenchmarkSyncMapSet/test_set_write/read_with_90%_writers-4      	    2967	    389416 ns/op	   18052 B/op	    1799 allocs/op
BenchmarkSyncMapSet/test_set_write/read_with_100%_writers-4     	    1578	    664198 ns/op	   20311 B/op	    2002 allocs/op
PASS
coverage: 100.0% of statements
ok  	geekbrains/examples/lesson5/hw/float_map	18.916s

```

На моей нагрузке почти всегда выигрывает SyncMap, кроме вариантов с более 90%  записи

![image](https://user-images.githubusercontent.com/74767911/120779748-0e108d80-c530-11eb-8b56-6c47e3b971ca.png)
